### PR TITLE
Fix Blameless Culture header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ This resource is for on-call practitioners who want to iteratively learn from in
 ### What Is a Postmortem?
 The who, what, when, and why of [postmortems](what_is.md).
 
-Blameless Culture#
+### Blameless Culture
 A successful postmortem process is based on a culture of honesty, learning, and accountability. Culture change requires management buy-in, but you can lead culture change no matter your role. This section describes common challenges in building a culture of continuous learning through postmortems, and strategies for overcoming them.
 
 - [The Blameless Postmortem](culture/blameless.md)


### PR DESCRIPTION
The "Blameless Culture" header is broken. Judging by the legend on the right, it should be on the same level as the "How to Write a Postmortem" header/section:
[![Screen-Shot-2022-04-28-at-13-51-12.png](https://i.postimg.cc/4N6KbhFg/Screen-Shot-2022-04-28-at-13-51-12.png)](https://postimg.cc/crJ4d6S9)